### PR TITLE
Chapter 3: Fix example showing appendFileSync() arguments instead of appendFile()

### DIFF
--- a/03-Coordinating-IO/content.md
+++ b/03-Coordinating-IO/content.md
@@ -344,7 +344,10 @@ fs.readFile(path.join(cwd, 'file.dat'), (err, bytes) => {
     if (err) { console.error(err); process.exit(1); }
     fs.appendFile(
       path.join(cwd, 'log.txt'),
-      (new Date) + ' ' + (bytes.length - clean.length) + ' bytes removed\n'
+      (new Date) + ' ' + (bytes.length - clean.length) + ' bytes removed\n',
+      (err) => {
+        if (err) { console.error(err); process.exit(1); }
+      }
     )
   })
 })


### PR DESCRIPTION
This example in Chapter 3 does not run as-is since it's missing the callback